### PR TITLE
Update cross_compiling.md

### DIFF
--- a/labs/docs/cross_compiling.md
+++ b/labs/docs/cross_compiling.md
@@ -14,6 +14,10 @@
 
     for os in linux windows darwin; do GOOS=${os} GOARCH=amd64 CGO_ENABLED=0 ./make.bash —no-clean; done
 
+**NOTE**: Make sure to not include the OS you are actually running in this list or you will end up with
+a build of Go that has CGO disabled. So if you are running on OSX, for exampple, this should be:
+
+    for os in linux windows; do GOOS=${os} GOARCH=amd64 CGO_ENABLED=0 ./make.bash —no-clean; done
 
 ## Cross Compile csv2json_server
 


### PR DESCRIPTION
I am running the build of Go we built in your workshop a couple of months ago. I discovered that although `go env` thinks that `CGO_ENABLED=1` it's not actually in the build, which ends up with some oddity. It turns out that we disabled it when building the cross-compiling tools.  This PR adds a little note to explain how to not end up like this when building the cross-compiling tools.

Thanks again!
